### PR TITLE
Building and deploying Sphinx multiversion docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,10 +57,18 @@ jobs:
       - name: Create 404 page (redirect to humble)
         run: |
           cat > _site/404.html <<'EOF'
-          <!doctype html><meta charset="utf-8">
-          <meta http-equiv="refresh" content="0; url=/doosan-robotics-ros-manual/Humble/">
+          <!doctype html>
+          <meta charset="utf-8">
+          <meta http-equiv="refresh" content="0; url=/doosan-robotics-ros-manual/humble/">
+          <link rel="canonical" href="/doosan-robotics-ros-manual/humble/">
           <title>Not Found · Redirecting…</title>
-          <p>Page not found. Go to <a href="/doosan-robotics-ros-manual/Humble/">Humble docs</a>.</p>
+          <p>Page not found. Go to <a href="/doosan-robotics-ros-manual/humble/">Humble docs</a>.</p>
+          <script>
+            (function() {
+              var target = "/doosan-robotics-ros-manual/humble/";
+              if (location.pathname !== target) location.replace(target);
+            })();
+          </script>
           EOF
 
       - name: Ensure .nojekyll

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,8 @@
 name: Build & Deploy Sphinx Docs
+
 on:
   push:
-    branches: [ main, master, feature/**, docs/** ]
+    branches: [ humble, jazzy ]
   workflow_dispatch:
 
 permissions:
@@ -17,27 +18,72 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Checkout (full history for SMV)
+        uses: actions/checkout@v4
         with:
-          python-version: "3.10"
-      - name: Install deps
+          fetch-depth: 0
+
+      - name: Fetch all branches/tags
+        run: |
+          git fetch --all --tags --prune
+          git fetch origin +refs/heads/*:refs/remotes/origin/*
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-      - name: Build Sphinx
-        run: sphinx-build -b html source build
+          pip install "sphinx==7.2.6" "sphinx-multiversion==0.2.4" "sphinx_rtd_theme>=1.3.0"
+
+      - name: Build with sphinx-multiversion
+        run: |
+          python -m sphinx_multiversion source _site
+
+      - name: Create landing page (redirect to Humble)
+        run: |
+          mkdir -p _site
+          cat > _site/index.html <<'EOF'
+          <!doctype html><meta charset="utf-8">
+          <meta http-equiv="refresh" content="0; url=/doosan-robotics-ros-manual/humble/">
+          <link rel="canonical" href="/doosan-robotics-ros-manual/humble/">
+          <title>Redirecting…</title>
+          <p>Redirecting to <a href="/doosan-robotics-ros-manual/humble/">Humble docs</a>…</p>
+          EOF
+
+      - name: Create 404 page (redirect to humble)
+        run: |
+          cat > _site/404.html <<'EOF'
+          <!doctype html><meta charset="utf-8">
+          <meta http-equiv="refresh" content="0; url=/doosan-robotics-ros-manual/Humble/">
+          <title>Not Found · Redirecting…</title>
+          <p>Page not found. Go to <a href="/doosan-robotics-ros-manual/Humble/">Humble docs</a>.</p>
+          EOF
+
+      - name: Ensure .nojekyll
+        run: |
+          touch _site/.nojekyll
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: build
+          path: _site
 
   deploy:
     needs: build
-    runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
     steps:
-      - id: deployment
+      - name: Deploy to GitHub Pages
+        id: deployment
         uses: actions/deploy-pages@v4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-sphinx<9
-sphinx-rtd-theme<4
-
+sphinx>=7.2
+sphinx-rtd-theme>=2.0
+sphinx-multiversion>=0.2.4

--- a/source/_templates/versions.html
+++ b/source/_templates/versions.html
@@ -1,0 +1,38 @@
+{# _templates/versions.html #}
+{% set show_switcher = (versions and (versions.branches or versions.tags)) %}
+{% if (READTHEDOCS or display_lower_left) and show_switcher %}
+  <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
+    <span class="rst-current-version" data-toggle="rst-current-version">
+      <span class="fa fa-book"></span>
+      {{ current_version.name if current_version else 'unknown' }}
+      <span class="fa fa-caret-down"></span>
+    </span>
+
+    <div class="rst-other-versions">
+      {% set allowed = ['humble', 'jazzy'] %}
+      {% set items = [] %}
+      {% for b in versions.branches %}
+        {% if b.name in allowed %}
+          {% set _ = items.append(b) %}
+        {% endif %}
+      {% endfor %}
+
+      {% set items = items|sort(attribute='name') %}
+      {% set items = (items|selectattr('name','equalto','jazzy')|list) + (items|rejectattr('name','equalto','jazzy')|list) %}
+
+      {% if items %}
+      <dl>
+        <dt>{{ _('Versions') }}</dt>
+        {% for v in items %}
+          {% set label = v.name %}
+          <dd>
+            <a href="{{ v.url }}">
+              {{ label }}{% if v.name == 'jazzy' %} <span style="font-size:.85em;">(jazzy)</span>{% endif %}
+            </a>
+          </dd>
+        {% endfor %}
+      </dl>
+      {% endif %}
+    </div>
+  </div>
+{% endif %}

--- a/source/_templates/versions.html
+++ b/source/_templates/versions.html
@@ -1,6 +1,6 @@
 {# _templates/versions.html #}
 {% set show_switcher = (versions and (versions.branches or versions.tags)) %}
-{% if (READTHEDOCS or display_lower_left) and show_switcher %}
+{% if show_switcher %}
   <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
       <span class="fa fa-book"></span>
@@ -24,11 +24,8 @@
       <dl>
         <dt>{{ _('Versions') }}</dt>
         {% for v in items %}
-          {% set label = v.name %}
           <dd>
-            <a href="{{ v.url }}">
-              {{ label }}{% if v.name == 'jazzy' %} <span style="font-size:.85em;">(jazzy)</span>{% endif %}
-            </a>
+            <a href="{{ v.url }}">{{ v.name }}</a>
           </dd>
         {% endfor %}
       </dl>

--- a/source/conf.py
+++ b/source/conf.py
@@ -1,11 +1,11 @@
-
-
+# -- Project information -----------------------------------------------------
 project = 'Doosan Robotics ROS2 Manual'
-copyright = '2025, ms'
 author = 'ms'
+copyright = '2025, ms'
 version = '1.0'
 release = '1.0'
 
+# -- General configuration ---------------------------------------------------
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
@@ -24,11 +24,14 @@ rst_prolog = """
    <br />
 """
 
+# -- sphinx-multiversion -----------------------------------------------------
+smv_remote_whitelist = r'^origin$'
+smv_branch_whitelist = r'^(humble|jazzy)$'
+
+# -- HTML output -------------------------------------------------------------
 html_theme = 'sphinx_rtd_theme'
 html_static_path = ['_static']
-
 html_css_files = ['manual.css']
-
 html_title = 'ROS2 Manual Guide v1.0'
 html_logo = '_static/doosan_logo.png'
 
@@ -36,8 +39,8 @@ html_sidebars = {
     "**": [
         "localtoc.html",
         "relations.html",
-        "searchbox.html", 
-        "versions.html",  
+        "searchbox.html",
+        "versions.html",
     ],
 }
 
@@ -46,8 +49,4 @@ html_theme_options = {
     'sticky_navigation': True,
     'navigation_depth': 4,
     'titles_only': False,
-}
-
-html_context = {
-    'display_lower_left': True,
 }

--- a/source/conf.py
+++ b/source/conf.py
@@ -1,10 +1,4 @@
-# Configuration file for the Sphinx documentation builder.
-#
-# For the full list of built-in configuration values, see the documentation:
-# https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-# -- Project information -----------------------------------------------------
-# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = 'Doosan Robotics ROS2 Manual'
 copyright = '2025, ms'
@@ -12,19 +6,17 @@ author = 'ms'
 version = '1.0'
 release = '1.0'
 
-# -- General configuration ---------------------------------------------------
-# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
-
 extensions = [
-    'sphinx.ext.autodoc',     # 자동 문서화: docstring 기반
-    'sphinx.ext.napoleon',    # 구글/넘피 스타일 docstring 파싱
-    'sphinx.ext.todo',        # TODO 지원 (.. todo::)
-    'sphinx.ext.viewcode'     # 소스코드 보기 링크
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.todo',
+    'sphinx.ext.viewcode',
+    'sphinx_multiversion',
+    'sphinx.ext.githubpages',
 ]
 
-
 templates_path = ['_templates']
-exclude_patterns = []
+exclude_patterns = ['_build', '_site', 'Thumbs.db', '.DS_Store']
 
 rst_prolog = """
 .. |br| raw:: html
@@ -32,26 +24,30 @@ rst_prolog = """
    <br />
 """
 
-# -- Options for HTML output -------------------------------------------------
-# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
-
 html_theme = 'sphinx_rtd_theme'
 html_static_path = ['_static']
 
-# Add custom CSS
-html_css_files = [
-    'manual.css',
-]
+html_css_files = ['manual.css']
 
-# 문서 제목 변경
 html_title = 'ROS2 Manual Guide v1.0'
-html_logo = 'tutorials/images/etc/Doosan_logo.png' # logo
-# html_favicon = '_static/favicon.ico'
+html_logo = '_static/doosan_logo.png'
 
 html_sidebars = {
-    '**': [
-        'globaltoc.html',
-        'relations.html',
-        'searchbox.html'
-    ]
+    "**": [
+        "localtoc.html",
+        "relations.html",
+        "searchbox.html", 
+        "versions.html",  
+    ],
+}
+
+html_theme_options = {
+    'collapse_navigation': False,
+    'sticky_navigation': True,
+    'navigation_depth': 4,
+    'titles_only': False,
+}
+
+html_context = {
+    'display_lower_left': True,
 }


### PR DESCRIPTION
- Added CI workflow to build documentation with Sphinx and sphinx-multiversion

- Generates docs for both humble and jazzy branches

- Deploys the built site to GitHub Pages with landing/404 redirects

- Ensures .nojekyll for static assets